### PR TITLE
🎨 better error handling

### DIFF
--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -77,7 +77,51 @@ function Strategy(options, verify) {
  */
 util.inherits(Strategy, OAuth2Strategy);
 
-Strategy.prototype.authenticate = function (req, options) {
+Strategy.prototype.makeRequest = function makeRequest(options, done) {
+    this._oauth2._request(
+        options.method || 'GET',
+        options.url,
+        {"content-type": "application/json"},
+        JSON.stringify(options.body || {}),
+        null,
+        function (err, body) {
+            if (err) {
+                if (err.data) {
+                    try {
+                        err = JSON.parse(err.data);
+                    } catch (err) {
+                        debug(err);
+
+                        return done(new errors.InternalServerError({
+                            message: 'Encountered unexpected error for Ghost Auth request: ' + options.url
+                        }));
+                    }
+                }
+
+                debug(err);
+
+                return done(new errors.IgnitionError({
+                    statusCode: err.statusCode,
+                    message: err.message,
+                    help: 'Encountered unexpected error for Ghost Auth request: ' + options.url,
+                    errorType: err.errorType || err.name
+                }));
+            }
+
+            try {
+                body = JSON.parse(body || null);
+                return done(null, body);
+            } catch (err) {
+                debug(err);
+
+                return done(new errors.InternalServerError({
+                    message: 'Encountered unexpected error for Ghost Auth request: ' + options.url
+                }));
+            }
+        });
+};
+
+Strategy.prototype.authenticate = function authenticate(req, options) {
     options || (options = {});
 
     var oldHint = options.loginHint;
@@ -86,46 +130,36 @@ Strategy.prototype.authenticate = function (req, options) {
     options.loginHint = oldHint
 };
 
-Strategy.prototype.registerClient = function (options) {
+Strategy.prototype.registerClient = function registerClient(options) {
     options = options || {};
 
     var self = this,
         clientName = options.clientName || 'client';
 
     return new Promise(function (resolve, reject) {
-        self._oauth2._request(
-            "POST",
-            self._registerURL,
-            {"content-type": "application/json"},
-            JSON.stringify({
+        self.makeRequest({
+            method: 'POST',
+            url: self._registerURL,
+            body: {
                 client_name: clientName,
                 redirect_uri: self._callbackURL,
                 blog_uri: self.blogUri
-            }),
-            null,
-            function (err, body) {
-                if (err) {
-                    debug(err);
-                    return reject(new errors.BadRequestError({err: err}));
-                }
+            }
+        }, function (err, body) {
+            if (err) {
+                return reject(err);
+            }
 
-                try {
-                    body = JSON.parse(body || null);
-
-                    debug('registered client', body);
-                    return resolve(body);
-                } catch (err) {
-                    debug(err);
-                    return reject(new errors.BadRequestError({err: err}));
-                }
-            });
+            debug('registered client', body);
+            resolve(body);
+        });
     });
 };
 
 /**
  * If you register a client and your blog url changes afterwards, you can use this function to update the callbackURL.
  */
-Strategy.prototype.changeCallbackURL = function (options) {
+Strategy.prototype.changeCallbackURL = function changeCallbackURL(options) {
     options = options || {};
 
     var self = this,
@@ -136,36 +170,26 @@ Strategy.prototype.changeCallbackURL = function (options) {
     debug('changeCallbackURL: ' + JSON.stringify(options));
 
     return new Promise(function (resolve, reject) {
-        self._oauth2._request(
-            "POST",
-            self._updateRedirectUri,
-            {"content-type": "application/json"},
-            JSON.stringify({
+        self.makeRequest({
+            method: 'POST',
+            url: self._updateRedirectUri,
+            body: {
                 redirect_uri: redirect_uri,
                 client_id: clientId,
                 client_secret: clientSecret
-            }),
-            null,
-            function (err, body) {
-                if (err) {
-                    debug(err);
-                    return reject(new errors.BadRequestError({err: err}));
-                }
+            }
+        }, function (err, body) {
+            if (err) {
+                return reject(err);
+            }
 
-                try {
-                    body = JSON.parse(body || null);
-
-                    debug('changed client callback url', body);
-                    return resolve(body);
-                } catch (err) {
-                    debug(err);
-                    return reject(new errors.BadRequestError({err: err}));
-                }
-            });
+            debug('changed client callback url', body);
+            resolve(body);
+        });
     });
 };
 
-Strategy.prototype.setClient = function (client) {
+Strategy.prototype.setClient = function setClient(client) {
     this._oauth2._clientId = client.client_id;
     this._oauth2._clientSecret = client.client_secret;
 };
@@ -177,7 +201,7 @@ Strategy.prototype.setClient = function (client) {
  * @param {Function} done
  * @api protected
  */
-Strategy.prototype.userProfile = function (accessToken, done) {
+Strategy.prototype.userProfile = function userProfile(accessToken, done) {
     debug('get user profile', accessToken);
     debug('get user profile', this._userProfileURL);
 
@@ -198,12 +222,12 @@ Strategy.prototype.userProfile = function (accessToken, done) {
             done(null, json);
         } catch (err) {
             debug(err);
-            return done(new errors.NoPermissionError({err: err}));
+            return done(new errors.InternalServerError());
         }
     });
 };
 
-Strategy.prototype.changePassword = function (options, done) {
+Strategy.prototype.changePassword = function changePassword(options, done) {
     options = options || {};
 
     var accessToken = options.accessToken,
@@ -211,32 +235,24 @@ Strategy.prototype.changePassword = function (options, done) {
         newPassword = options.newPassword,
         self = this;
 
-    self._oauth2._request(
-        "PUT",
-        self._changePasswordURL,
-        {"content-type": "application/json"},
-        JSON.stringify({
-            access_token: accessToken,
-            oldPassword: oldPassword,
-            newPassword: newPassword
-        }),
-        null,
-        function (err, body) {
+    return new Promise(function (resolve, reject) {
+        self.makeRequest({
+            method: 'PUT',
+            url: self._changePasswordURL,
+            body: {
+                access_token: accessToken,
+                oldPassword: oldPassword,
+                newPassword: newPassword
+            }
+        }, function (err, body) {
             if (err) {
-                debug(err);
-                return done(new errors.NoPermissionError({err: err}));
+                return reject(err);
             }
 
-            try {
-                body = JSON.parse(body || null);
-
-                debug('change password', body);
-                return done(null, body);
-            } catch (err) {
-                debug(err);
-                return done(new errors.NoPermissionError({err: err}));
-            }
+            debug('change password', body);
+            resolve(body);
         });
+    });
 };
 
 /**


### PR DESCRIPTION
no issue

- wrap request logic into a function -> makeRequest
- the response of the library has wrapped the error into {statusCode: .., data: "error as string"}
- it can also return a flat error
- this PR is a breaking change because it returns changePassword as Promise